### PR TITLE
Add quotes around failed child template name

### DIFF
--- a/lib/childTemplates.js
+++ b/lib/childTemplates.js
@@ -73,7 +73,7 @@ ChildTemplates.prototype.evaluateChildTemplates = function (request, response, e
 
     self.reporter.documentStore.collection('templates').find({ name: templateName }, request).then(function (res) {
       if (res.length < 1) {
-        self.reporter.logger.debug('Child template \'' + templateName + '\' was not found, skipping.')
+        self.reporter.logger.debug('Child template "' + templateName + '" was not found, skipping.')
         return done(null)
       }
 

--- a/lib/childTemplates.js
+++ b/lib/childTemplates.js
@@ -73,7 +73,7 @@ ChildTemplates.prototype.evaluateChildTemplates = function (request, response, e
 
     self.reporter.documentStore.collection('templates').find({ name: templateName }, request).then(function (res) {
       if (res.length < 1) {
-        self.reporter.logger.debug('Child template ' + templateName + ' was not found, skipping.')
+        self.reporter.logger.debug('Child template \'' + templateName + '\' was not found, skipping.')
         return done(null)
       }
 


### PR DESCRIPTION
I had a problem where I was typing

`{#child child-report, @data.paramA=blah}`

I got an error on the console that read:
`Child template child-report, was not found, skipping.`

The comma was the problem, but I read it as part of the error message, so wasn't sure what was going on yet. By surrounding it in quotes, the error message will now read:

`Child template 'child-report,' was not found, skipping.`

Which should hopefully make it more obvious that it is parsing the comma as part of the template name.